### PR TITLE
PLAT-112 - updates to support OTP 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changelog for FTPoison v0.2.0
+
+- Relax Elixir version to minimum of 1.11
+- Replace use of inets library with ftp library for OTP 24 support
 # Changelog for FTPoison v0.1.1
 
 - Bump Elixir version to 1.6.6

--- a/lib/ftpoison/base.ex
+++ b/lib/ftpoison/base.ex
@@ -12,7 +12,7 @@ defmodule FTPoison.Base do
         end
       end
 
-      @doc "Starts a standalone FTP client process (without the Inets service framework)
+      @doc "Starts a standalone FTP client process (without the ftp service framework)
       and opens a session with the FTP server at Host."
       @spec open(String.t(), map()) :: nil
       def open(host, options \\ %{}) do
@@ -63,9 +63,9 @@ defmodule FTPoison.Base do
 
       @spec start(String.t()) :: pid() | nil
       def start(host) do
-        start_inets()
+        :ftp.start()
 
-        case :inets.start(:ftpc, host: to_charlist(host)) do
+        case :ftp.open(to_charlist(host)) do
           {:ok, pid} -> pid
           e -> handle_error(e)
         end
@@ -73,7 +73,8 @@ defmodule FTPoison.Base do
 
       @spec stop(pid()) :: any()
       def stop(pid) do
-        :inets.stop(:ftpc, pid)
+        :ftp.close(pid)
+        :ftp.stop()
       end
 
       @spec user(pid(), String.t(), String.t()) :: pid() | nil
@@ -82,11 +83,6 @@ defmodule FTPoison.Base do
           :ok -> pid
           e -> handle_error(e)
         end
-      end
-
-      @spec start_inets :: :ok
-      defp start_inets do
-        :inets.start()
       end
 
       @spec to_charlist(String.t()) :: charlist()

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule FTPoison.Mixfile do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.2.0"
 
   def project do
     [
       app: :ftpoison,
       version: @version,
-      elixir: "~> 1.11.2",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -38,7 +38,7 @@ defmodule FTPoison.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger, :ftp, :inets]
+      extra_applications: [:logger, :ftp]
     ]
   end
 

--- a/test/ftpoison_test.exs
+++ b/test/ftpoison_test.exs
@@ -5,7 +5,7 @@ defmodule FTPoisonTest do
   test """
   start/1
   given valid host string
-  will start an inets ftp connection
+  will start an ftp connection
   """ do
     pid = FTPoison.start("localhost")
     refute is_nil(pid)
@@ -16,18 +16,20 @@ defmodule FTPoisonTest do
   given invalid host
   will respond with appropriate error
   """ do
-    assert_raise FTPoison.Error, "Host is not found, FTP server is not found, or connection is rejected by FTP server.", fn ->
-      FTPoison.start("notaserver")
-    end
+    assert_raise FTPoison.Error,
+                 "Host is not found, FTP server is not found, or connection is rejected by FTP server.",
+                 fn ->
+                   FTPoison.start("notaserver")
+                 end
   end
 
   test """
   start/1
   given valid host
-  and inets is already started
+  and ftp is already started
   does not fail to start server
   """ do
-    :inets.start
+    :ftp.start()
     pid = FTPoison.start("localhost")
     refute is_nil(pid)
   end
@@ -38,6 +40,7 @@ defmodule FTPoisonTest do
   returns current working directory as a String
   """ do
     pid = FTPoison.start("localhost")
+
     assert_raise FTPoison.Error, " Please login with USER and PASS.\r\n", fn ->
       FTPoison.pwd(pid) == "/"
     end
@@ -49,6 +52,7 @@ defmodule FTPoisonTest do
   returns the listing as a String
   """ do
     pid = FTPoison.start("localhost")
+
     assert_raise FTPoison.Error, " Please login with USER and PASS.\r\n", fn ->
       FTPoison.list(pid) == []
     end


### PR DESCRIPTION
FTPoison is no longer working in monorepo after the elixir 1.12/OTP 24 upgrade.

OTP 24 upgraded inets to version 7 which drops ftp support: https://www.erlang.org/patches/otp-24.0#OTP-16722

As such this app had to be rewritten to use elixir's ftp app. This was done using this guide:
https://www.erlang.org/doc/apps/ftp/ftp_client.html#getting-started

**QA**
This repo has tests but none pass and I couldn't get them to pass. They seem to require having an ftp server running on localhost. :shrug: 

The best way to test is to run the same code that monorepo would run here: https://github.com/revzilla/monorepo/blob/master/redline/apps/redline_web_store/web/services/cyclegear/sku_inventory_adjustment_import.ex#L55

1) Pull down this PR
2) Assuming you have `asdf` installed, add a .tools-versions file with these contents:
```
erlang 24.3.4.4
elixir 1.12.3-otp-24
```
3) install those versions if needed
4) `iex -S mix`
5) run the code
```
    "cyclegear.hostedftp.com"
    |> FTPoison.start()
    |> FTPoison.user("RZUser", "[REDACTED - HIT ME UP FOR THE REAL PASS]")
    |> FTPoison.cd("ROBIS")
    |> FTPoison.recv("robis.csv", "/home/gregharnly/temp.csv")
    |> FTPoison.stop()
```
6) confirm the csv successfully downloaded